### PR TITLE
Support saving commands started without a shell

### DIFF
--- a/scripts/load-layout.sh
+++ b/scripts/load-layout.sh
@@ -49,6 +49,8 @@ pane_exists() {
         \grep -q "^$pane_index$"
 }
 
+shell_basename=$(basename "$SHELL")
+
 # Restore all panes.
 grep '^pane' "$layouts_dir/$session_name" |
     while IFS=$t read -r line_type window_index pane_index pane_current_path pane_full_command; do
@@ -57,16 +59,20 @@ grep '^pane' "$layouts_dir/$session_name" |
             tmux new-window -t "$session_name:$window_index"
         fi
 
+        if [ "$(basename "$pane_full_command")" != "$shell_basename" ]; then
+            pane_full_command="$pane_full_command; exec $SHELL"
+        fi
+
         if pane_exists "$window_index" "$pane_index"; then
             # Overwrite existing pane.
             pane_id="$(tmux display-message -p -F "#{pane_id}" -t "$session_name:$window_index")"
-            tmux split-window -t "$session_name:$window_index" -c "$pane_current_path" ${pane_full_command:+"$pane_full_command; exec $SHELL"}
+            tmux split-window -t "$session_name:$window_index" -c "$pane_current_path" "$pane_full_command"
             tmux kill-pane -t "$pane_id"
         else
             # Create new pane
-            tmux split-window -t "$session_name:$window_index" -c "$pane_current_path" ${pane_full_command:+"$pane_full_command; exec $SHELL"}
+            tmux split-window -t "$session_name:$window_index" -c "$pane_current_path" "$pane_full_command"
         fi
-    done 
+    done
 
 # Restore window configuration.
 grep '^window' "$layouts_dir/$session_name" |

--- a/scripts/save-layout.sh
+++ b/scripts/save-layout.sh
@@ -10,11 +10,18 @@ t=$(printf '\t')
 # Create an empty session file.
 :>"$layouts_dir/$session"
 
+OUR_PID=$$
+
 # Save panes.
 tmux list-panes -s -F "#I$t#P$t#{pane_current_path}$t#{pane_pid}" |
     while IFS=$t read -r window_index pane_index pane_current_path pane_pid; do
-        full_command=$(ps -ao "ppid,args" | sed "s/^ *//" | grep "^${pane_pid}" | cut -d' ' -f2-)
-        echo "pane$t$window_index$t$pane_index$t$pane_current_path$t$full_command" >> "$layouts_dir/$session"
+      full_command=$(command ps -Ao "pid,ppid,args" | sed -E 's/ +/ /g' | grep -E "^ ([[:digit:]]+ ${pane_pid}|${pane_pid})" | grep -v "^ $OUR_PID" | cut -d' ' -f4- | tail -n 1)
+
+      if [ "$full_command" = "-bash" ]; then
+        full_command="bash"
+      fi
+
+      echo "pane$t$window_index$t$pane_index$t$pane_current_path$t$full_command" >> "$layouts_dir/$session"
     done
 
 # Save window configuration.


### PR DESCRIPTION
I've added some edge case handling for more complex setups. Particularly my window manager's application launcher actually finds the tmux associated with the workspace and starts the application there, and I want to save these.

Also changed things so that loading a session doesn't run an extra shell after the original command